### PR TITLE
use array of key-value pairs instead of dictionary

### DIFF
--- a/Exercises/Exercise003.cs
+++ b/Exercises/Exercise003.cs
@@ -6,25 +6,34 @@ namespace Exercises
 {
     public class Exercise003
     {
-        private readonly Dictionary<string, int> iceCreamFlavoursCodes = new Dictionary<string, int>
+        private readonly KeyValuePair<string, int>[] iceCreamFlavoursCodes = new KeyValuePair<string, int>[]
         {
-            { "Pistachio", 0 },
-            { "Raspberry Ripple", 1 },
-            { "Vanilla", 2 },
-            { "Mint Chocolate Chip", 3 },
-            { "Chocolate", 4 },
-            { "Mango Sorbet", 5 }
+            new KeyValuePair<string, int>("Pistachio", 0 ),
+            new KeyValuePair<string, int>("Raspberry Ripple", 1 ),
+            new KeyValuePair<string, int>("Vanilla", 2 ),
+            new KeyValuePair<string, int>("Mint Chocolate Chip", 3 ),
+            new KeyValuePair<string, int>("Chocolate", 4 ),
+            new KeyValuePair<string, int>("Mango Sorbet", 5 )
         };
 
-        public string[] IceCreamFlavours => iceCreamFlavoursCodes.Keys.ToArray();
+        public string[] IceCreamFlavours => iceCreamFlavoursCodes
+            .Select(item => item.Key)
+            .ToArray();
 
-        public int IceCreamCode(string iceCreamFlavour) => iceCreamFlavoursCodes[iceCreamFlavour];
+        public int IceCreamCode(string iceCreamFlavour) => iceCreamFlavoursCodes
+            .FirstOrDefault(item => item.Key == iceCreamFlavour) 
+            .Value; 
 
         // Initially I was tempted to store the ice cream flavours in a string array, 
         // and let the ice cream code just be the index of the favour at the array.
         // But then I wasn't sure if Pip the cat will always be encoding ice cream flavours by following 
-        // this 0,1,2,3,4,5 pattern. So I decided to use a dictionary to store the { flavour, code }
+        // this 0,1,2,3,4,5 pattern. So I decided to use an array of key-value pairs { flavour, code }
         // to have more flexibility.
+        //
+        // In a previous git commit, I was using dictionary to achieve this flexibility,
+        // but after reading the C# doc for dictionary I realise that dictionary
+        // doesn't guarantee the ordering of its elements, so I switched to using
+        // array of key-value pairs instead.
         //
         // The commented out code below is the "simpler" implementation (works as long as Pip encodes their 
         // ice cream flavours based on the 0,1,2,3,4,5 pattern)


### PR DESCRIPTION
Changed iceCreamFlavoursCode type from Dictionary<string, int> to KeyValuePair<string, int>[] so that iceCreamFlavoursCode would have a reliable item order.

The microsoft c# documentation for Dictionary mentions that "The order in which the items are returned is undefined."
And some stackoverflow posts even says "do not rely on dictionary to preserve item order".